### PR TITLE
Convert checkable_label method to html_context

### DIFF
--- a/lib/formular/element.rb
+++ b/lib/formular/element.rb
@@ -50,11 +50,11 @@ module Formular
       self.tag_name = name
     end
 
-    def self.call(options={}, &block)
-      new(options, &block)
+    def self.call(**options, &block)
+      new(**options, &block)
     end
 
-    def initialize(options={}, &block)
+    def initialize(**options, &block)
       @builder = options.delete(:builder)
       normalize_attributes(options)
       @block = block

--- a/lib/formular/elements.rb
+++ b/lib/formular/elements.rb
@@ -224,7 +224,7 @@ module Formular
       end
 
       html(:with_collection) do |element|
-        concat element.collection.map(&:checkable_label).join('')
+        element.collection.each { |item| concat item.to_html(context: :checkable_label) }
         concat element.hidden_tag
       end
 

--- a/lib/formular/elements.rb
+++ b/lib/formular/elements.rb
@@ -224,7 +224,7 @@ module Formular
       end
 
       html(:with_collection) do |element|
-        element.collection.each { |item| concat item.to_html(context: :checkable_label) }
+        concat element.to_html(context: :collection)
         concat element.hidden_tag
       end
 

--- a/lib/formular/elements/bootstrap3/checkable_controls.rb
+++ b/lib/formular/elements/bootstrap3/checkable_controls.rb
@@ -10,36 +10,18 @@ module Formular
         module InlineCheckable
           include Formular::Elements::Module
 
-          html(:with_group_label) do |input|
+          html(:wrapped) do |input|
             input.wrapper do
               concat input.group_label
               concat input.hidden_tag unless input.collection?
-
-              concat Formular::Elements::Div.(content: input.collection.map{ |item|
-                item.to_html(context: :checkable_label)
-              }.join(''))
-
+              if input.has_group_label?
+                concat Formular::Elements::Div.(content: input.to_html(context: :collection))
+              else
+                concat input.to_html(context: :collection)
+              end
               concat input.hidden_tag if input.collection?
               concat input.hint
               concat input.error
-            end
-          end
-
-          html(:wrapped) do |input|
-            if input.has_group_label?
-              input.to_html(context: :with_group_label)
-            else
-              input.wrapper do
-                concat input.hidden_tag unless input.collection?
-
-                input.collection.each { |item|
-                  concat item.to_html(context: :checkable_label)
-                }
-
-                concat input.hidden_tag if input.collection?
-                concat input.hint
-                concat input.error
-              end
             end
           end
         end # class InlineCheckable
@@ -73,13 +55,17 @@ module Formular
             input.wrapper do
               concat input.group_label
               concat input.hidden_tag unless input.collection?
-              input.collection.each do |control|
-                concat control.inner_wrapper { control.to_html(context: :checkable_label) }
-              end
+              concat input.to_html(context: :collection)
               concat input.hidden_tag if input.collection?
               concat input.hint
               concat input.error
             end
+          end
+
+          html(:collection) do |input|
+            input.collection.map { |control|
+              control.inner_wrapper { control.to_html(context: :checkable_label) }
+            }.join('')
           end
 
           module InstanceMethods

--- a/lib/formular/elements/bootstrap3/checkable_controls.rb
+++ b/lib/formular/elements/bootstrap3/checkable_controls.rb
@@ -14,7 +14,11 @@ module Formular
             input.wrapper do
               concat input.group_label
               concat input.hidden_tag unless input.collection?
-              concat Formular::Elements::Div.(content: input.collection.map(&:checkable_label).join(''))
+
+              concat Formular::Elements::Div.(content: input.collection.map{ |item|
+                item.to_html(context: :checkable_label)
+              }.join(''))
+
               concat input.hidden_tag if input.collection?
               concat input.hint
               concat input.error
@@ -27,7 +31,11 @@ module Formular
             else
               input.wrapper do
                 concat input.hidden_tag unless input.collection?
-                concat input.collection.map(&:checkable_label).join('')
+
+                input.collection.each { |item|
+                  concat item.to_html(context: :checkable_label)
+                }
+
                 concat input.hidden_tag if input.collection?
                 concat input.hint
                 concat input.error
@@ -66,7 +74,7 @@ module Formular
               concat input.group_label
               concat input.hidden_tag unless input.collection?
               input.collection.each do |control|
-                concat control.inner_wrapper { control.checkable_label }
+                concat control.inner_wrapper { control.to_html(context: :checkable_label) }
               end
               concat input.hidden_tag if input.collection?
               concat input.hint

--- a/lib/formular/elements/bootstrap3/horizontal.rb
+++ b/lib/formular/elements/bootstrap3/horizontal.rb
@@ -3,6 +3,7 @@ require 'formular/elements'
 require 'formular/elements/modules/container'
 require 'formular/elements/module'
 require 'formular/elements/bootstrap3'
+require 'formular/elements/bootstrap3/checkable_controls'
 module Formular
   module Elements
     module Bootstrap3
@@ -45,38 +46,19 @@ module Formular
             input.group_label
           end
 
+          html(:input_column) do |input|
+            concat input.hidden_tag
+            concat input.to_html(context: :collection)
+            concat input.hint
+            concat input.error
+          end
+
           module InstanceMethods
             def column_class
               has_group_label? ? [] : builder.class.column_classes[:left_offset]
             end
           end
         end # module WrappedCheckableControl
-
-        module StackedCheckableControl
-          include Formular::Elements::Module
-          include WrappedCheckableControl
-
-          html(:input_column) do |input|
-            concat input.hidden_tag
-            input.collection.each do |control|
-              concat control.inner_wrapper { control.to_html(context: :checkable_label) }
-            end
-            concat input.hint
-            concat input.error
-          end
-        end # module StackedCheckableControl
-
-        module InlineCheckableControl
-          include Formular::Elements::Module
-          include WrappedCheckableControl
-
-          html(:input_column) do |input|
-            concat input.hidden_tag
-            input.collection.each { |control| concat control.to_html(context: :checkable_label) }
-            concat input.hint
-            concat input.error
-          end
-        end # module InlineCheckableControl
 
         class InputColumnWrapper < Formular::Elements::Div
           set_default :class, :column_class
@@ -119,19 +101,21 @@ module Formular
         end # class Submit
 
         class Checkbox < Formular::Elements::Bootstrap3::Checkbox
-          include StackedCheckableControl
+          include Formular::Elements::Bootstrap3::CheckableControls::StackedCheckable
+          include WrappedCheckableControl
         end # class Checkbox
 
         class Radio < Formular::Elements::Bootstrap3::Radio
-          include StackedCheckableControl
+          include Formular::Elements::Bootstrap3::CheckableControls::StackedCheckable
+          include WrappedCheckableControl
         end # class Radio
 
         class InlineCheckbox < Formular::Elements::Bootstrap3::InlineCheckbox
-          include InlineCheckableControl
+          include WrappedCheckableControl
         end # class InlineCheckbox
 
         class InlineRadio < Formular::Elements::Bootstrap3::InlineRadio
-          include InlineCheckableControl
+          include WrappedCheckableControl
         end # class InlineRadio
       end # module Horizontal
     end # module Bootstrap3

--- a/lib/formular/elements/bootstrap3/horizontal.rb
+++ b/lib/formular/elements/bootstrap3/horizontal.rb
@@ -59,7 +59,7 @@ module Formular
           html(:input_column) do |input|
             concat input.hidden_tag
             input.collection.each do |control|
-              concat control.inner_wrapper { control.checkable_label }
+              concat control.inner_wrapper { control.to_html(context: :checkable_label) }
             end
             concat input.hint
             concat input.error
@@ -72,7 +72,7 @@ module Formular
 
           html(:input_column) do |input|
             concat input.hidden_tag
-            input.collection.each { |control| concat control.checkable_label }
+            input.collection.each { |control| concat control.to_html(context: :checkable_label) }
             concat input.hint
             concat input.error
           end

--- a/lib/formular/elements/foundation6/checkable_controls.rb
+++ b/lib/formular/elements/foundation6/checkable_controls.rb
@@ -16,7 +16,7 @@ module Formular
             input.wrapper do
               concat input.group_label
               concat input.hidden_tag unless input.collection?
-              input.collection.each { |control| concat control.checkable_label }
+              input.collection.each { |control| concat control.to_html(context: :checkable_label) }
               concat input.hidden_tag if input.collection?
               concat input.hint
               concat input.error
@@ -39,12 +39,12 @@ module Formular
               concat input.group_label
               concat input.hidden_tag unless input.collection?
               input.collection.each do |control|
-                concat input.builder.div(content: control.checkable_label).to_s
+                concat input.builder.div(content: control.to_html(context: :checkable_label))
               end
               concat input.hidden_tag if input.collection?
               concat input.hint
               concat input.error
-            end.to_s
+            end
           end
         end # class StackedCheckable
 

--- a/lib/formular/elements/foundation6/checkable_controls.rb
+++ b/lib/formular/elements/foundation6/checkable_controls.rb
@@ -16,11 +16,11 @@ module Formular
             input.wrapper do
               concat input.group_label
               concat input.hidden_tag unless input.collection?
-              input.collection.each { |control| concat control.to_html(context: :checkable_label) }
+              concat input.to_html(context: :collection)
               concat input.hidden_tag if input.collection?
               concat input.hint
               concat input.error
-            end.to_s
+            end
           end
 
           module InstanceMethods
@@ -34,17 +34,10 @@ module Formular
           include Formular::Elements::Module
           include Checkable
 
-          html(:wrapped) do |input|
-            input.wrapper do
-              concat input.group_label
-              concat input.hidden_tag unless input.collection?
-              input.collection.each do |control|
-                concat input.builder.div(content: control.to_html(context: :checkable_label))
-              end
-              concat input.hidden_tag if input.collection?
-              concat input.hint
-              concat input.error
-            end
+          html(:collection) do |input|
+            input.collection.map { |control|
+              input.builder.div(content: control.to_html(context: :checkable_label))
+            }.join('')
           end
         end # class StackedCheckable
 

--- a/lib/formular/elements/modules/checkable.rb
+++ b/lib/formular/elements/modules/checkable.rb
@@ -29,6 +29,12 @@ module Formular
           end
         end
 
+        html(:collection) do |input|
+          input.collection.map { |item|
+            item.to_html(context: :checkable_label)
+          }.join('')
+        end
+
         module InstanceMethods
           def group_label
             return '' unless has_group_label?

--- a/lib/formular/elements/modules/checkable.rb
+++ b/lib/formular/elements/modules/checkable.rb
@@ -14,29 +14,30 @@ module Formular
         include Collection
         include Labels
 
-        add_option_keys :control_label_options, :label_options, :label
+        add_option_keys :control_label_options
 
         set_default :checked, 'checked', if: :is_checked?
 
-        module InstanceMethods
-          def checkable_label
-            label_options[:content] = if has_label?
-                                        "#{to_html(context: :default)} #{label_text}"
-                                      else
-                                        to_html(context: :default).to_s
-                                      end
-
-            Formular::Elements::Label.(label_options).to_s
+        html(:checkable_label) do |input|
+          Formular::Elements::Label.(input.label_options) do
+            if has_label?
+              concat input.to_html(context: :default)
+              concat " #{input.label_text}"
+            else
+              to_html(context: :default)
+            end
           end
+        end
 
+        module InstanceMethods
           def group_label
             return '' unless has_group_label?
-            label_options[:content] = options[:label]
+            label_options[:content] = label_text
             builder.checkable_group_label(label_options).to_s
           end
 
           def has_group_label?
-            collection.size > 1 && !options[:label].nil?
+            collection.size > 1 && has_label?
           end
 
           def collection

--- a/lib/formular/elements/modules/labels.rb
+++ b/lib/formular/elements/modules/labels.rb
@@ -20,7 +20,6 @@ module Formular
             !label_text.nil? && label_text != false
           end
 
-          private
           def label_options
             @label_options ||= Attributes[options[:label_options]]
           end


### PR DESCRIPTION
Fixes #5.

I've converted the checkable_label method to an HtmlBlock context.

This flows better to me as the idea behind the html_blocks is to define what you want your html to look like. Defining simple html in a method is fine, but when it gets more complex it should really be an html_block.

You can provide your own block by overriding it in your class e.g.

```
html(:checkable_label) do |input|
  Formular::Elements::Label.(input.options[:label_options]) do
    concat input.to_html(context: :default)
    concat Span.()
    concat " #{input.label_text}"
  end
end
```