### PR TITLE
Ensure elements are added

### DIFF
--- a/lib/formular/builder.rb
+++ b/lib/formular/builder.rb
@@ -6,9 +6,10 @@ module Formular
     inheritable_attr :elements
     self.elements = {}
 
+
     def self.element_set(**elements)
-      elements.merge!(elements)
-      define_element_methods(**elements)
+      self.elements.merge!(elements)
+      define_element_methods(self.elements)
     end
 
     def self.define_element_methods(**elements)

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -3,12 +3,13 @@ require 'formular/builder'
 require 'formular/elements'
 
 describe Formular::Builder do
+  BuilderElements =
+    {label: Formular::Elements::Label,
+     input: Formular::Elements::Input,
+     form: Formular::Elements::Form}.freeze
+
   let(:builder) {
-    Formular::Builder.new(
-      label: Formular::Elements::Label,
-      input: Formular::Elements::Input,
-      form: Formular::Elements::Form
-    )
+    Formular::Builder.new(BuilderElements)
   }
 
   describe '#define_element_methods' do
@@ -33,7 +34,7 @@ describe Formular::Builder do
         concat f.input(type: 'text', value: 'Something exciting')
       end
       form.to_s.must_equal %(<form action="/questions/13" method="post" accept-charset=\"utf-8\"><input name=\"utf8\" type=\"hidden\" value=\"✓\"/><label class="control-label">What colour is the sky?</label><input type="text" value="Something exciting"/></form>)
-    end
+	end
 
     it '#outputs without block (use end)' do
       form = builder.form(action: '/questions/13')
@@ -49,6 +50,29 @@ describe Formular::Builder do
       form = builder.form(content: "<h1>Fab Form</h1>")
 
       form.to_s.must_equal %(<form method="post" accept-charset=\"utf-8\"><input name=\"utf8\" type=\"hidden\" value=\"✓\"/><h1>Fab Form</h1></form>)
+    end
+  end
+
+  describe 'builder elements' do
+    Password = Class.new(Formular::Element)
+    Builder = Class.new(Formular::Builder) do
+      element_set(BuilderElements)
+    end
+    InheritedBuilder = Class.new(Builder)
+    PasswordInheritedBuilder = Class.new(InheritedBuilder) do
+      element_set(password: Password)
+    end
+
+    it "stores elements" do
+      Builder.elements.must_equal BuilderElements
+    end
+
+    it "inherits elements" do
+      InheritedBuilder.elements.must_equal Builder.elements
+    end
+
+    it "extends inherited elements" do
+      PasswordInheritedBuilder.elements[:password].must_equal Password
     end
   end
 end


### PR DESCRIPTION
Hi @fran-worley ,

here's a small fix which fixes filling `self.elements`, because now it [merges][1] with local incoming elements and never sets the singleton class variable. Hence, `self.elements` is always empty, however all specs pass, because of all methods were always defined. 

[1]: https://github.com/trailblazer/formular/blob/66c89e84fefe1664eea8e9644bf8fd3bd24abbe5/lib/formular/builder.rb#L10