### PR TITLE
Change f.button type: :button to f.submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In your view, you're now ready to use Formular's API to render forms.
   .form-group
     = f.textarea :content, placeholder: "And your story...", rows: 9
   .form-group
-    = f.button type: :submit, value: "Submit!", class: [:btn, :'btn-lg', :'btn-default']
+    = f.submit value: "Submit!", class: [:btn, :'btn-lg', :'btn-default']
 ```
 
 Note that a lot of this code can be done automatically by Formular.


### PR DESCRIPTION
`f.button` is not a valid element for formular builders (and will raise `NoMethodError: undefined method 'button' for #<Formular::Builders::Basic:0x007f91ed12e680>`).

Instead it appears you use [submit](https://github.com/trailblazer/formular/blob/master/lib/formular/builders/basic.rb#L23) for the submit button.

This commit updates the README to reflect this.