### PR TITLE
fix ugly minitest warnings

### DIFF
--- a/test/element/errors_test.rb
+++ b/test/element/errors_test.rb
@@ -61,7 +61,7 @@ describe 'errors module' do
 
       it 'option is false then should be nil' do
         element = builder.wrapped_input(:body, error: false)
-        element.error_text.must_equal nil
+        element.error_text.must_be_nil
       end
 
       it 'return custom message' do

--- a/test/element/hints_test.rb
+++ b/test/element/hints_test.rb
@@ -36,7 +36,7 @@ describe 'hints module' do
     describe '#hint_message' do
       it 'option is false then should be nil' do
         element = builder.wrapped_input(:body, hint: false)
-        element.hint_text.must_equal nil
+        element.hint_text.must_be_nil
       end
 
       it 'return custom message' do

--- a/test/element_test.rb
+++ b/test/element_test.rb
@@ -41,7 +41,7 @@ describe Formular::Element do
     end
 
     it 'should evaluate condition correctly' do
-      element.options[:option_1].must_equal nil
+      element.options[:option_1].must_be_nil
     end
 
     it 'should exclude nil keys' do


### PR DESCRIPTION
I just wanted to run the tests and get this error:
Use assert_nil if expecting nil from formular/vendor/bundle/ruby/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6

So I fixed it by replacing every `must_equal nil` with `must_be_nil`.
Thanks.