### PR TITLE
escape html in attribute values refs #29

### DIFF
--- a/lib/formular/attributes.rb
+++ b/lib/formular/attributes.rb
@@ -39,7 +39,8 @@ module Formular
     end
 
     def val_to_string(value)
-      value.is_a?(Array) ? value.join(' ') : value
+      val = value.is_a?(Array) ? value.join(' ') : value
+      val.is_a?(String) ? CGI.escape_html(val) : val
     end
   end # class Attributes
 end # module Formular

--- a/lib/formular/elements.rb
+++ b/lib/formular/elements.rb
@@ -128,7 +128,8 @@ module Formular
       add_option_keys :value
 
       def content
-        options[:value] || super
+        val = options[:value] || super
+        val.is_a?(String) ? CGI.escape_html(val) : val
       end
     end # class Textarea
 

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -35,5 +35,10 @@ class AttributesTest < Minitest::Spec
       attrs = Formular::Attributes[{}]
       attrs.to_html.must_equal ""
     end
+
+    it "should escape attribute values by default" do
+      attrs = Formular::Attributes[value: '" foo="<b>bar</b>"']
+      attrs.to_html.must_equal %(value="&quot; foo=&quot;&lt;b&gt;bar&lt;/b&gt;&quot;")
+    end
   end
 end

--- a/test/elements_test.rb
+++ b/test/elements_test.rb
@@ -146,6 +146,11 @@ describe 'core elements' do
       element.to_s.must_equal %(<textarea>Some lovely words here...</textarea>)
     end
 
+    it '#to_s contents as html escaped string' do
+      element = Formular::Element::Textarea.(content: '</textarea><p>Something evil</p><textarea>')
+      element.to_s.must_equal %(<textarea>&lt;/textarea&gt;&lt;p&gt;Something evil&lt;/p&gt;&lt;textarea&gt;</textarea>)
+    end
+
     it '#to_s contents as block' do
       element = Formular::Element::Textarea.() do
         concat 'Part 1 text; '


### PR DESCRIPTION
We need to escape HTML for attribute values, otherwise we have serious XSS-issues if someone inserts something that is redisplayed without proper escaping. You never want a value in you attributes that is able to destroy your HTML, so we have to escape it.
This should not be optional, I think.