### PR TITLE
Button controls should render "value" attributes

### DIFF
--- a/lib/formular/elements.rb
+++ b/lib/formular/elements.rb
@@ -162,13 +162,10 @@ module Formular
       html { closed_start_tag }
     end # class Submit
 
-    class Button < Formular::Element::Container
-      tag :button
-      add_option_keys :value
+    class Button < Container
+      include Formular::Element::Modules::Control
 
-      def content
-        options[:value] || super
-      end
+      tag :button
     end # class Button
 
     class Input < Control

--- a/test/element/bootstrap3/input_group_test.rb
+++ b/test/element/bootstrap3/input_group_test.rb
@@ -33,7 +33,7 @@ describe 'Bootstrap3::InputGroup' do
     element = builder.input_group(:title, label: 'Title', value: 'John Smith') do |input|
       concat input.group_addon('<input name="default[]" id="default" type="checkbox" value="1">')
       concat input.control
-      concat input.group_btn(builder.submit(value: 'Go!'))
+      concat input.group_btn(builder.submit(content: 'Go!'))
     end
     element.to_s.must_equal %(<div class="form-group"><label for="title" class="control-label">Title</label><div class="input-group"><span class="input-group-addon"><input name="default[]" id="default" type="checkbox" value="1"></span><input value="John Smith" name="title" id="title" type="text" class="form-control"/><span class="input-group-btn"><button class="btn btn-default" type="submit">Go!</button></span></div></div>)
   end
@@ -44,9 +44,9 @@ describe 'Bootstrap3::InputGroup' do
     html = ig.start
     html << ig.group_addon('<input name="default[]" id="default" type="checkbox" value="1">').to_s
     html << ig.control.to_s
-    html << ig.group_btn(builder.submit(value: 'Go!')).to_s
+    html << ig.group_btn(builder.submit(value: 'stop', content: 'Please, No!')).to_s
     html << ig.end
-    html.must_equal %(<div class="form-group"><label for="title" class="control-label">Title</label><div class="input-group"><span class="input-group-addon"><input name="default[]" id="default" type="checkbox" value="1"></span><input value="John Smith" name="title" id="title" type="text" class="form-control"/><span class="input-group-btn"><button class="btn btn-default" type="submit">Go!</button></span></div></div>)
+    html.must_equal %(<div class="form-group"><label for="title" class="control-label">Title</label><div class="input-group"><span class="input-group-addon"><input name="default[]" id="default" type="checkbox" value="1"></span><input value="John Smith" name="title" id="title" type="text" class="form-control"/><span class="input-group-btn"><button value="stop" class="btn btn-default" type="submit">Please, No!</button></span></div></div>)
   end
 
   describe "with errors" do

--- a/test/element/bootstrap3_test.rb
+++ b/test/element/bootstrap3_test.rb
@@ -34,7 +34,7 @@ describe Formular::Element::Bootstrap3 do
 
   describe Formular::Element::Bootstrap3::Submit do
     it "#to_s" do
-      element = builder.submit(value: 'Go Go Go!!')
+      element = builder.submit(content: 'Go Go Go!!')
       element.to_s.must_equal %(<button class="btn btn-default" type="submit">Go Go Go!!</button>)
     end
   end

--- a/test/element/foundation6/input_group_test.rb
+++ b/test/element/foundation6/input_group_test.rb
@@ -30,7 +30,7 @@ describe 'Foundation6::InputGroup' do
     element = builder.input_group(:title, value: 'John Smith') do |input|
       concat input.group_label('<input name="default[]" id="default" type="checkbox" value="1">')
       concat input.group_input
-      concat input.group_button(builder.submit(value: 'Go!'))
+      concat input.group_button(builder.submit(content: 'Go!'))
     end
     element.to_s.must_equal %(<fieldset><div class="input-group"><span class="input-group-label"><input name="default[]" id="default" type="checkbox" value="1"></span><input value="John Smith" name="title" id="title" type="text" class="input-group-field"/><div class="input-group-button"><button class="success button" type="submit">Go!</button></div></div></fieldset>)
   end
@@ -62,7 +62,7 @@ describe 'Foundation6::InputGroup' do
       element = builder.input_group(:title, value: 'John Smith', label: 'Title') do |input|
         concat input.group_label('<input name="default[]" id="default" type="checkbox" value="1">')
         concat input.group_input
-        concat input.group_button(builder.submit(value: 'Go!'))
+        concat input.group_button(builder.submit(content: 'Go!'))
       end
       element.to_s.must_equal %(<fieldset><label for="title">Title</label><div class="input-group"><span class="input-group-label"><input name="default[]" id="default" type="checkbox" value="1"></span><input value="John Smith" name="title" id="title" type="text" class="input-group-field"/><div class="input-group-button"><button class="success button" type="submit">Go!</button></div></div></fieldset>)
     end
@@ -95,7 +95,7 @@ describe 'Foundation6::InputGroup' do
       element = builder.input_group(:title, value: 'John Smith') do |input|
         concat input.group_label('<input name="default[]" id="default" type="checkbox" value="1">')
         concat input.group_input
-        concat input.group_button(builder.submit(value: 'Go!'))
+        concat input.group_button(builder.submit(content: 'Go!'))
       end
       element.to_s.must_equal %(<fieldset><div class="input-group"><span class="is-invalid-label input-group-label"><input name="default[]" id="default" type="checkbox" value="1"></span><input value="John Smith" name="title" id="title" type="text" class="input-group-field is-invalid-input"/><div class="input-group-button"><button class="success button" type="submit">Go!</button></div></div><span class="form-error is-visible">is missing</span></fieldset>)
     end
@@ -128,7 +128,7 @@ describe 'Foundation6::InputGroup' do
       element = builder.input_group(:title, value: 'John Smith', hint: 'Some handy hint') do |input|
         concat input.group_label('<input name="default[]" id="default" type="checkbox" value="1">')
         concat input.group_input
-        concat input.group_button(builder.submit(value: 'Go!'))
+        concat input.group_button(builder.submit(content: 'Go!'))
       end
       element.to_s.must_equal %(<fieldset><div class="input-group"><span class="input-group-label"><input name="default[]" id="default" type="checkbox" value="1"></span><input value="John Smith" name="title" id="title" type="text" aria-describedby=\"title_hint\" class="input-group-field"/><div class="input-group-button"><button class="success button" type="submit">Go!</button></div></div><p id="title_hint" class="help-text">Some handy hint</p></fieldset>)
     end
@@ -165,7 +165,7 @@ describe 'Foundation6::InputGroup' do
       element = builder.input_group(:title, label: 'Title', value: 'John Smith', hint: 'Some handy hint') do |input|
         concat input.group_label('<input name="default[]" id="default" type="checkbox" value="1">')
         concat input.group_input
-        concat input.group_button(builder.submit(value: 'Go!'))
+        concat input.group_button(builder.submit(content: 'Go!'))
       end
       element.to_s.must_equal %(<fieldset><label class="is-invalid-label" for="title">Title</label><div class="input-group"><span class="is-invalid-label input-group-label"><input name="default[]" id="default" type="checkbox" value="1"></span><input value="John Smith" name="title" id="title" type="text" aria-describedby=\"title_hint\" class="input-group-field is-invalid-input"/><div class="input-group-button"><button class="success button" type="submit">Go!</button></div></div><p id="title_hint" class="help-text">Some handy hint</p><span class="form-error is-visible">is missing</span></fieldset>)
     end

--- a/test/element/foundation6_test.rb
+++ b/test/element/foundation6_test.rb
@@ -70,7 +70,7 @@ describe Formular::Element::Foundation6 do
 
   describe Formular::Element::Foundation6::Submit do
     it "#to_s" do
-      builder.submit(value: "Submit!").to_s.must_equal %(<button class="success button" type="submit">Submit!</button>)
+      builder.submit(content: "Submit!").to_s.must_equal %(<button class="success button" type="submit">Submit!</button>)
     end
   end
 end

--- a/test/elements_test.rb
+++ b/test/elements_test.rb
@@ -25,9 +25,14 @@ describe 'core elements' do
   end # Formular::Element::Button
 
   describe Formular::Element::Button do
-    it 'returns correct html' do
-      element = Formular::Element::Button.(href: '/some_path', value: 'Button')
-      element.to_s.must_equal %(<button href="/some_path">Button</button>)
+    it '#to_s' do
+      element = Formular::Element::Button.(name: 'my-name', value: 1, content: 'Jimmy')
+      element.to_s.must_equal %(<button name="my-name" value="1">Jimmy</button>)
+    end
+
+    it 'escapes value attribute' do
+      element = Formular::Element::Button.(value: "I'm a little teapot whose spout is > 10cm")
+      element.to_s.must_equal %(<button value="I&#39;m a little teapot whose spout is &gt; 10cm"></button>)
     end
   end # Formular::Element::Button
 


### PR DESCRIPTION
`<button>` elements can have `value` attributes: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button

This PR adds breaking changes:
* `Formular::Element::Button` no longer blacklists `value` attributes passed as an option
* `Formular::Element::Button#content` is no longer overridden by the :value option
* Updated tests to reflect the new expected output.