### PR TITLE
Now Formular::Helper.builder as initiliazer works!

### DIFF
--- a/lib/formular/helper.rb
+++ b/lib/formular/helper.rb
@@ -22,18 +22,19 @@ module Formular
 
     class << self
       def _builder
-        @builder || load_builder(:basic)
+        @builder || :basic
       end
       attr_writer :builder
 
       def builder(name)
-        self.builder = load_builder(name)
+        self.builder = name
       end
 
       def load_builder(name)
         require "formular/builders/#{name}"
         Formular::Builders.const_get(BUILDERS.fetch(name))
       end
+
     end
 
     private
@@ -41,7 +42,9 @@ module Formular
     def builder(model, **options)
       builder_name = options.delete(:builder)
 
-      builder = builder_name ? Formular::Helper.load_builder(builder_name) : Formular::Helper._builder
+      builder_name ||= Formular::Helper._builder
+
+      builder = Formular::Helper.load_builder(builder_name)
       options[:model] ||= model
 
       builder.new(options)

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -7,17 +7,17 @@ class HelperTest < Minitest::Spec
   model = OpenStruct.new
 
   it "should be Basic by default" do
-    Formular::Helper._builder.must_equal Formular::Builders::Basic
+    Formular::Helper._builder.must_equal :basic
   end
 
   it "should set default builder" do
     Formular::Helper.builder(:bootstrap3)
-    Formular::Helper._builder.must_equal Formular::Builders::Bootstrap3
+    Formular::Helper._builder.must_equal :bootstrap3
     Formular::Helper.builder(:basic) # return it back for other tests
   end
 
   it "should allow me to override the default builder" do
-    Formular::Helper._builder.must_equal Formular::Builders::Basic
+    Formular::Helper._builder.must_equal :basic
     form(model, "", builder: :foundation6).builder.class.must_equal Formular::Builders::Foundation6
   end
 end


### PR DESCRIPTION
Ciao,
since day one I was trying to use `Formular::Helper.builder= :bootstrap3` as initializer in my projects but it wouldn't work here below how I have fixed it.
**ISSUE:**
`_builder` is called when the `builder` option is not present in `form` so if `@builder` is not set `load_builder(:basic)` is called which is perfect *BUT* if `@builder` is initialized, `load_builder` is not called at all.
**FIXED:**
first make sure that `builder_name` is either set by the `form` method or by the initializer or just `basic` and then call `load_builder`.

Hope this makes sense
ciao 