### PR TITLE
Travis: use jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ rvm:
   - 2.3.1
   - 2.4.0
   - rbx-2
-  - jruby-9.1.1.0
+  - jruby-9.1.13.0
   - ruby-head
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
 matrix:
   allow_failures:
-    - rvm: jruby-9.1.1.0
+    - rvm: jruby-9.1.13.0
     - rvm: rbx-2
     - rvm: ruby-head
     - rvm: jruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html