### PR TITLE
Allow checkbox collections to be matched with given value(s)

### DIFF
--- a/lib/formular/element/modules/checkable.rb
+++ b/lib/formular/element/modules/checkable.rb
@@ -74,17 +74,21 @@ module Formular
           end
 
           private
+
           def is_checked?
-            !options[:checked].nil? || reader_value == options[:value]
+            return !options[:checked].nil? if options.has_key?(:checked)
+            option_val = options[:value].to_s
+            Array(options[:collection_values_to_match] || reader_value).map(&:to_s).include?(option_val)
           end
 
           def collection_base_options
             opts = attributes.select { |k, v| ![:name, :id, :checked, :class].include?(k) }
             # FIXME due to class merging, we'll end up with duplicate classes...
-            opts[:attribute_name] = attribute_name if attribute_name
-            opts[:builder]        = builder if builder
-            opts[:label_options]  = options[:control_label_options] if options[:control_label_options]
-            opts[:name]           = options[:name] if options[:name] # do we need this??
+            opts[:attribute_name]             = attribute_name if attribute_name
+            opts[:builder]                    = builder if builder
+            opts[:label_options]              = options[:control_label_options] if options[:control_label_options]
+            opts[:collection_values_to_match] = options[:value]
+            opts[:name]                       = options[:name] if options[:name] # do we need this??
 
             opts
           end

--- a/lib/formular/elements.rb
+++ b/lib/formular/elements.rb
@@ -315,6 +315,7 @@ module Formular
       private
 
       def default_checked_value
+        return if collection?
         options[:checked_value] || '1'
       end
 

--- a/test/elements_test.rb
+++ b/test/elements_test.rb
@@ -290,13 +290,39 @@ describe 'core elements' do
 
     describe "with collection" do
       it '#to_s default methods' do
-        element = Formular::Element::Checkbox.(name: 'public[]',  collection: [['False', 0], ['True', 1]])
-        element.to_s.must_equal %(<label><input type="checkbox" value="0" name="public[]" id="public_0"/> False</label><label><input type="checkbox" value="1" name="public[]" id="public_1"/> True</label><input value="" name="public[]" type="hidden"/>)
+        element = Formular::Element::Checkbox.(name: 'public[]', collection: [['False', 0], ['True', 1]])
+        element.to_s.must_equal %(<label><input type="checkbox" name="public[]" value="0" id="public_0"/> False</label><label><input type="checkbox" name="public[]" value="1" id="public_1"/> True</label><input value="" name="public[]" type="hidden"/>)
       end
 
       it '#to_s custom methods' do
         element = Formular::Element::Checkbox.(name: 'public[]', collection: [2..4, 3..5], label_method: :min, value_method: :max)
-        element.to_s.must_equal %(<label><input type="checkbox" value="4" name="public[]" id="public_4"/> 2</label><label><input type="checkbox" value="5" name="public[]" id="public_5"/> 3</label><input value="" name="public[]" type="hidden"/>)
+        element.to_s.must_equal %(<label><input type="checkbox" name="public[]" value="4" id="public_4"/> 2</label><label><input type="checkbox" name="public[]" value="5" id="public_5"/> 3</label><input value="" name="public[]" type="hidden"/>)
+      end
+
+      it '#to_s checks matching single value' do
+        element = Formular::Element::Checkbox.(name: 'public[]', value: 1, collection: [['Zero', 0], ['One', 1]])
+        element.to_s.must_equal %(<label><input value="0" type="checkbox" name="public[]" id="public_0"/> Zero</label><label><input value="1" type="checkbox" name="public[]" id="public_1" checked="checked"/> One</label><input value="" name="public[]" type="hidden"/>)
+      end
+
+      it '#to_s checks matching multiple values' do
+        element = Formular::Element::Checkbox.(name: 'public[]', value: [0, 1], collection: [['Zero', 0], ['One', 1]])
+        element.to_s.must_equal %(<label><input value="0" type="checkbox" name="public[]" id="public_0" checked="checked"/> Zero</label><label><input value="1" type="checkbox" name="public[]" id="public_1" checked="checked"/> One</label><input value="" name="public[]" type="hidden"/>)
+      end
+    end
+
+    describe 'through builder' do
+      it "matches an attribute's scalar value with a given collection" do
+        model = OpenStruct.new number: 1
+        builder = Formular::Builders::Basic.new model: model
+        element = builder.checkbox(:number, collection: [['Zero', 0], ['One', 1]])
+        element.to_s.must_equal %(<label><input type="checkbox" name="number[]" value="0" id="number_0"/> Zero</label><label><input type="checkbox" name="number[]" value="1" id="number_1" checked="checked"/> One</label><input value="" name="number[]" type="hidden"/>)
+      end
+
+      it "matches attribute's array of values with a given collection" do
+        model = OpenStruct.new number: [0, 1]
+        builder = Formular::Builders::Basic.new model: model
+        element = builder.checkbox(:number, collection: [['Zero', 0], ['One', 1]])
+        element.to_s.must_equal %(<label><input type="checkbox" name="number[]" value="0" id="number_0" checked="checked"/> Zero</label><label><input type="checkbox" name="number[]" value="1" id="number_1" checked="checked"/> One</label><input value="" name="number[]" type="hidden"/>)
       end
     end
   end # Formular::Element::Checkbox
@@ -470,7 +496,7 @@ describe 'core elements' do
         element.to_s.must_equal %(<select name="public[]" multiple="true"><option value="0">False</option><option value="1">True</option></select>)
       end
 
-      it 'has correct selecteds options' do
+      it 'has correct selected options' do
         element_opts[:value] = [0,1]
         element = Formular::Element::Select.(element_opts)
         element.to_s.must_equal %(<select name="public[]" multiple="true"><option value="0" selected="selected">False</option><option value="1" selected="selected">True</option></select>)


### PR DESCRIPTION
This technically works, but tests have not yet been updated to reflect the effective order of html attributes. I wanted to run the intent of this PR by you guys before fixing those, and refactoring this changeset to be a little easier on the eyes.

When dealing with checkbox collections one should be able to designate what value(s) should be matched and therefore rendered as `checked="checked"`. This is especially useful when called as a method on a builder. Following the lead of `Formular::Element::Select` I'm using the `:value` option for this purpose, but admittedly it does get a little confusing with both `:default` and `:with_collection` contexts, and with other options like `:checked_value`.

Regardless, if the direction posited in [`elements_test.rb`](https://github.com/trailblazer/formular/compare/master...bencallaway:allow-checkbox-collections-to-match-given-values?expand=1#diff-3d45e0a7edec39b17157bd37f02ddff8) looks right, then I can clean up & clarify my changes in `Formular::Element::Checkable` and add comparable test coverage for radio type inputs.